### PR TITLE
Add costack abstraction functions 

### DIFF
--- a/rustfmt.sh
+++ b/rustfmt.sh
@@ -1,0 +1,3 @@
+# This script runs rustfmt for the parts of the repo that uses it
+
+rustfmt ./src/syscalls.rs

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -17,6 +17,7 @@ pub enum SystemError {
     UnexpectedSize,
 }
 
+/// Minimal wrapping around a raw hypervisor call to push_costack. (Avoid unless strictly necessary)
 pub fn push_costack(data: &[u8]) {
     unsafe {
         let size = data.len();
@@ -25,6 +26,7 @@ pub fn push_costack(data: &[u8]) {
     }
 }
 
+/// Minimal wrapping around a raw hypervisor call to pop_costack. (Avoid unless strictly necessary)
 pub fn pop_costack_fixed(buffer: &mut [u8]) -> Result<u32, SystemError> {
     unsafe {
         let size = buffer.len();
@@ -37,116 +39,136 @@ pub fn pop_costack_fixed(buffer: &mut [u8]) -> Result<u32, SystemError> {
         }
     }
 }
+
+/// Pop and discard a value from the stack.
 pub fn discard_costack() {
     unsafe {
         __pop_costack(core::ptr::null_mut(), 0);
     }
 }
-/*
-pub fn pop_sccs() -> Result<Vec<u8>, SystemError>{
-    unsafe{
-        let actual_size = __peek_sccs(0 as *mut u8, 0, 0);
-        if actual_size > 0x8000_0000{
-            return Err(SystemError::Generic(actual_size as u32))
+
+macro_rules! pop_costack_typed {
+    ($TYPE:tt) => {{
+        const SIZE: usize = core::mem::size_of::<$TYPE>();
+        let mut buffer = [0; SIZE];
+        let result = match pop_costack_fixed(&mut buffer) {
+            Ok(v) => v,
+            Err(_e) => return Err(RecoverableError::ItemDoesntExist),
+        };
+
+        // For these functions we only allow the exact expected byte count
+        if result > SIZE as u32 {
+            return Err(RecoverableError::StackItemTooLarge);
+        } else if result < SIZE as u32 {
+            return Err(RecoverableError::StackItemTooSmall);
         }
-        let mut data = vec![];
-        data.resize(actual_size, 0);
-        let actual_size = __pop_sccs(data.as_mut_ptr(), actual_size) as u32;
-        if actual_size > 0x8000_0000{
-            Err(SystemError::Generic(actual_size))
-        }else{
-            Ok(data)
-        }
-    }
-}
-*/
 
-/// Pops an exactly u64 value from the stack.
-pub fn pop_costack_u64() -> Result<u64, SystemError> {
-    const SIZE: usize = 8;
-    let mut buffer = [0; SIZE];
-    let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32 {
-        return Err(SystemError::UnexpectedSize);
-    }
-    return Ok(unsafe { transmute::<[u8; SIZE], u64>(buffer) }.to_le());
+        Ok(unsafe { transmute::<[u8; SIZE], $TYPE>(buffer) })
+    }};
 }
 
-/// Pops an exactly u32 value from the stack.
-pub fn pop_costack_u32() -> Result<u32, SystemError> {
-    const SIZE: usize = 4;
-    let mut buffer = [0; SIZE];
-    let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32 {
-        return Err(SystemError::UnexpectedSize);
-    }
-    return Ok(unsafe { transmute::<[u8; SIZE], u32>(buffer) }.to_le());
+/// Pops an exact u64 value from the stack.
+pub fn pop_costack_u64() -> Result<u64, RecoverableError> {
+    pop_costack_typed!(u64)
 }
 
-/// Pops an exactly u16 value from the stack.
-pub fn pop_costack_u16() -> Result<u16, SystemError> {
-    const SIZE: usize = 2;
-    let mut buffer = [0; SIZE];
-    let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32 {
-        return Err(SystemError::UnexpectedSize);
-    }
-    return Ok(unsafe { transmute::<[u8; SIZE], u16>(buffer) }.to_le());
+/// Pops an exact u32 value from the stack.
+pub fn pop_costack_u32() -> Result<u32, RecoverableError> {
+    pop_costack_typed!(u32)
 }
 
-/// Pops an exactly u8 value from the stack.
-pub fn pop_costack_u8() -> Result<u8, SystemError> {
-    const SIZE: usize = 1;
-    let mut buffer = [0];
-    let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32 {
-        return Err(SystemError::UnexpectedSize);
-    }
-    return Ok(buffer[0]);
-}
-/// Pops a NeutronShortAddress value from the stack.
-pub fn pop_costack_address() -> Result<NeutronAddress, SystemError> {
-    const SIZE: usize = core::mem::size_of::<NeutronAddress>();
-    let mut buffer = [0; SIZE];
-    let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32 {
-        return Err(SystemError::UnexpectedSize);
-    }
-    return Ok(unsafe { transmute::<[u8; SIZE], NeutronAddress>(buffer) });
+/// Pops an exact u16 value from the stack.
+pub fn pop_costack_u16() -> Result<u16, RecoverableError> {
+    pop_costack_typed!(u16)
 }
 
-/// Pushes a NeutronShortAddress to the stack.
-pub fn push_costack_address(value: &NeutronAddress) {
-    const SIZE: usize = core::mem::size_of::<NeutronAddress>();
-    let t = unsafe { transmute::<NeutronAddress, [u8; SIZE]>(*value) };
-    push_costack(&t);
+/// Pops an exact u8 value from the stack.
+pub fn pop_costack_u8() -> Result<u8, RecoverableError> {
+    pop_costack_typed!(u8)
 }
 
-/// Pushes a u64 value to the stack.
+/// Pops an exact i64 value from the stack.
+pub fn pop_costack_i64() -> Result<i64, RecoverableError> {
+    pop_costack_typed!(i64)
+}
+
+/// Pops an exact i32 value from the stack.
+pub fn pop_costack_i32() -> Result<i32, RecoverableError> {
+    pop_costack_typed!(i32)
+}
+
+/// Pops an exact i16 value from the stack.
+pub fn pop_costack_i16() -> Result<i16, RecoverableError> {
+    pop_costack_typed!(i16)
+}
+
+/// Pops an exact i8 value from the stack.
+pub fn pop_costack_i8() -> Result<i8, RecoverableError> {
+    pop_costack_typed!(i8)
+}
+
+/// Pops an exact NeutronAddress value from the stack.
+pub fn pop_costack_address() -> Result<NeutronAddress, RecoverableError> {
+    pop_costack_typed!(NeutronAddress)
+}
+
+macro_rules! push_costack_typed {
+    ($VALUE:ident, $TYPE:tt) => {{
+        const SIZE: usize = core::mem::size_of::<$TYPE>();
+        let bytes = unsafe { transmute::<$TYPE, [u8; SIZE]>($VALUE) };
+        push_costack(&bytes);
+    }};
+    // Handle reference-type parameters (Only NeutronAddress currently)
+    (*$VALUE:ident, $TYPE:tt) => {{
+        const SIZE: usize = core::mem::size_of::<$TYPE>();
+        let bytes = unsafe { transmute::<$TYPE, [u8; SIZE]>(*$VALUE) };
+        push_costack(&bytes);
+    }};
+}
+
+/// Push an exact u64 value to the stack.
 pub fn push_costack_u64(value: u64) {
-    const SIZE: usize = 8;
-    let t = unsafe { transmute::<u64, [u8; SIZE]>(value) };
-    push_costack(&t);
+    push_costack_typed!(value, u64);
 }
-/// Pushes a u32 value to the stack.
+
+/// Push an exact u32 value to the stack.
 pub fn push_costack_u32(value: u32) {
-    const SIZE: usize = 4;
-    let t = unsafe { transmute::<u32, [u8; SIZE]>(value) };
-    push_costack(&t);
+    push_costack_typed!(value, u32);
 }
 
-/// Pushes a u64 value to the stack.
+/// Push an exact u16 value to the stack.
 pub fn push_costack_u16(value: u16) {
-    const SIZE: usize = 2;
-    let t = unsafe { transmute::<u16, [u8; SIZE]>(value) };
-    push_costack(&t);
+    push_costack_typed!(value, u16);
 }
 
-/// Pushes a u64 value to the stack.
+/// Push an exact u8 value to the stack.
 pub fn push_costack_u8(value: u8) {
-    const SIZE: usize = 1;
-    let t = unsafe { transmute::<u8, [u8; SIZE]>(value) };
-    push_costack(&t);
+    push_costack_typed!(value, u8);
+}
+
+/// Push an exact i64 value to the stack.
+pub fn push_costack_i64(value: i64) {
+    push_costack_typed!(value, i64);
+}
+
+/// Push an exact i32 value to the stack.
+pub fn push_costack_i32(value: i32) {
+    push_costack_typed!(value, i32);
+}
+
+/// Push an exact i16 value to the stack.
+pub fn push_costack_i16(value: i16) {
+    push_costack_typed!(value, i16);
+}
+
+/// Push an exact i8 value to the stack.
+pub fn push_costack_i8(value: i8) {
+    push_costack_typed!(value, i8);
+}
+
+/// Pushes an exact NeutronAddress to the stack.
+pub fn push_costack_address(value: &NeutronAddress) {
+    push_costack_typed!(*value, NeutronAddress);
 }
 
 pub fn get_self_address() -> NeutronAddress {

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -4,42 +4,41 @@
 //! These functions only do the basic methods of abstraction, such as returning results and pairs
 //! instead of taking mutable pointers for integers
 
-extern crate neutron_star_rt;
 extern crate neutron_common;
+extern crate neutron_star_rt;
 
-use neutron_star_rt::*;
-use neutron_common::*;
 use core::mem::transmute;
-
+use neutron_common::*;
+use neutron_star_rt::*;
 
 #[derive(core::fmt::Debug)]
-pub enum SystemError{
+pub enum SystemError {
     Generic(u32),
     UnexpectedSize,
 }
 
-pub fn push_costack(data: &[u8]){
-    unsafe{
+pub fn push_costack(data: &[u8]) {
+    unsafe {
         let size = data.len();
         let ptr = data.as_ptr();
         __push_costack(ptr, size);
     }
 }
 
-pub fn pop_costack_fixed(buffer: &mut [u8]) -> Result<u32, SystemError>{
-    unsafe{
+pub fn pop_costack_fixed(buffer: &mut [u8]) -> Result<u32, SystemError> {
+    unsafe {
         let size = buffer.len();
         let ptr = buffer.as_mut_ptr();
         let actual_size = __pop_costack(ptr, size) as u32;
-        if actual_size > 0x8000_0000{
+        if actual_size > 0x8000_0000 {
             Err(SystemError::Generic(actual_size))
-        }else{
+        } else {
             Ok(actual_size)
         }
     }
 }
-pub fn discard_costack(){
-    unsafe{
+pub fn discard_costack() {
+    unsafe {
         __pop_costack(core::ptr::null_mut(), 0);
     }
 }
@@ -62,117 +61,106 @@ pub fn pop_sccs() -> Result<Vec<u8>, SystemError>{
 }
 */
 
-/// Pops an exactly u64 value from the stack. 
-pub fn pop_costack_u64() -> Result<u64, SystemError>{
-    const SIZE:usize = 8;
+/// Pops an exactly u64 value from the stack.
+pub fn pop_costack_u64() -> Result<u64, SystemError> {
+    const SIZE: usize = 8;
     let mut buffer = [0; SIZE];
     let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32{
+    if result != SIZE as u32 {
         return Err(SystemError::UnexpectedSize);
     }
     return Ok(unsafe { transmute::<[u8; SIZE], u64>(buffer) }.to_le());
 }
 
-/// Pops an exactly u32 value from the stack. 
-pub fn pop_costack_u32() -> Result<u32, SystemError>{
-    const SIZE:usize = 4;
+/// Pops an exactly u32 value from the stack.
+pub fn pop_costack_u32() -> Result<u32, SystemError> {
+    const SIZE: usize = 4;
     let mut buffer = [0; SIZE];
     let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32{
+    if result != SIZE as u32 {
         return Err(SystemError::UnexpectedSize);
     }
     return Ok(unsafe { transmute::<[u8; SIZE], u32>(buffer) }.to_le());
 }
 
-/// Pops an exactly u16 value from the stack. 
-pub fn pop_costack_u16() -> Result<u16, SystemError>{
-    const SIZE:usize = 2;
+/// Pops an exactly u16 value from the stack.
+pub fn pop_costack_u16() -> Result<u16, SystemError> {
+    const SIZE: usize = 2;
     let mut buffer = [0; SIZE];
     let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32{
+    if result != SIZE as u32 {
         return Err(SystemError::UnexpectedSize);
     }
     return Ok(unsafe { transmute::<[u8; SIZE], u16>(buffer) }.to_le());
 }
 
-/// Pops an exactly u8 value from the stack. 
-pub fn pop_costack_u8() -> Result<u8, SystemError>{
-    const SIZE:usize = 1;
+/// Pops an exactly u8 value from the stack.
+pub fn pop_costack_u8() -> Result<u8, SystemError> {
+    const SIZE: usize = 1;
     let mut buffer = [0];
     let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32{
+    if result != SIZE as u32 {
         return Err(SystemError::UnexpectedSize);
     }
     return Ok(buffer[0]);
 }
-/// Pops a NeutronShortAddress value from the stack. 
-pub fn pop_costack_address() -> Result<NeutronAddress, SystemError>{
-    const SIZE:usize = core::mem::size_of::<NeutronAddress>();
+/// Pops a NeutronShortAddress value from the stack.
+pub fn pop_costack_address() -> Result<NeutronAddress, SystemError> {
+    const SIZE: usize = core::mem::size_of::<NeutronAddress>();
     let mut buffer = [0; SIZE];
     let result = pop_costack_fixed(&mut buffer)?;
-    if result != SIZE as u32{
+    if result != SIZE as u32 {
         return Err(SystemError::UnexpectedSize);
     }
-    return Ok(unsafe { transmute::<[u8; SIZE], NeutronAddress>(buffer)});
+    return Ok(unsafe { transmute::<[u8; SIZE], NeutronAddress>(buffer) });
 }
 
-/// Pushes a NeutronShortAddress to the stack. 
-pub fn push_costack_address(value: &NeutronAddress){
-    const SIZE:usize = core::mem::size_of::<NeutronAddress>();
-    let t = unsafe{
-        transmute::<NeutronAddress, [u8; SIZE]>(*value)
-    };
+/// Pushes a NeutronShortAddress to the stack.
+pub fn push_costack_address(value: &NeutronAddress) {
+    const SIZE: usize = core::mem::size_of::<NeutronAddress>();
+    let t = unsafe { transmute::<NeutronAddress, [u8; SIZE]>(*value) };
     push_costack(&t);
 }
 
-/// Pushes a u64 value to the stack. 
-pub fn push_costack_u64(value: u64){
-    const SIZE:usize = 8;
-    let t = unsafe{
-        transmute::<u64, [u8; SIZE]>(value)
-    };
+/// Pushes a u64 value to the stack.
+pub fn push_costack_u64(value: u64) {
+    const SIZE: usize = 8;
+    let t = unsafe { transmute::<u64, [u8; SIZE]>(value) };
     push_costack(&t);
 }
-/// Pushes a u32 value to the stack. 
-pub fn push_costack_u32(value: u32){
-    const SIZE:usize = 4;
-    let t = unsafe{
-        transmute::<u32, [u8; SIZE]>(value)
-    };
+/// Pushes a u32 value to the stack.
+pub fn push_costack_u32(value: u32) {
+    const SIZE: usize = 4;
+    let t = unsafe { transmute::<u32, [u8; SIZE]>(value) };
     push_costack(&t);
 }
 
-/// Pushes a u64 value to the stack. 
-pub fn push_costack_u16(value: u16){
-    const SIZE:usize = 2;
-    let t = unsafe{
-        transmute::<u16, [u8; SIZE]>(value)
-    };
+/// Pushes a u64 value to the stack.
+pub fn push_costack_u16(value: u16) {
+    const SIZE: usize = 2;
+    let t = unsafe { transmute::<u16, [u8; SIZE]>(value) };
     push_costack(&t);
 }
 
-/// Pushes a u64 value to the stack. 
-pub fn push_costack_u8(value: u8){
-    const SIZE:usize = 1;
-    let t = unsafe{
-        transmute::<u8, [u8; SIZE]>(value)
-    };
+/// Pushes a u64 value to the stack.
+pub fn push_costack_u8(value: u8) {
+    const SIZE: usize = 1;
+    let t = unsafe { transmute::<u8, [u8; SIZE]>(value) };
     push_costack(&t);
 }
 
-pub fn get_self_address() -> NeutronAddress{
+pub fn get_self_address() -> NeutronAddress {
     //TODO
     return NeutronAddress::default();
 }
 
-pub fn _system_call(element: u32, function: u32) -> Result<u32, SystemError>{
-    unsafe{
+pub fn _system_call(element: u32, function: u32) -> Result<u32, SystemError> {
+    unsafe {
         let result = __system_call(element, function);
-        if result >= 0x8000_0000{
+        if result >= 0x8000_0000 {
             Err(SystemError::Generic(result))
-        }else{
+        } else {
             Ok(result)
         }
     }
 }
-


### PR DESCRIPTION
Add basic neutron-star abstraction functions for pushing/popping single numeric values to/from the costack. 

Will be accompanied by a PR to neutron-host with the same name containing tests for added functionality. 