### PR TITLE
"Simple" comap ops

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# Just adding this for now to avoid unnecessarily split lines
+max_width = 140 # Bikeshed warning!

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -174,29 +174,29 @@ pub fn push_costack_address(value: &NeutronAddress) {
     push_costack_typed!(*value, NeutronAddress);
 }
 
-
-// All these are 1 byte headers -> only top byte is used, as following: 
+// All these are 1 byte headers -> only top byte is used, as following:
 // Bits 7-6 are 0   -> 1 byte header
 // Bit 5 is 0       -> numeric type
 // Bit 4 is 0       -> not hex/bignum display
 // Bit 3 is 0       -> not array
 // Bits 2-0 determine the actual type
-const ABI_VALUE_U8: u32       = 0b00000000 << 24;
-const ABI_VALUE_I8: u32       = 0b00000100 << 24;
-const ABI_VALUE_U16: u32      = 0b00000010 << 24;
-const ABI_VALUE_I16: u32      = 0b00000110 << 24;
-const ABI_VALUE_U32: u32      = 0b00000001 << 24;
-const ABI_VALUE_I32: u32      = 0b00000101 << 24;
-const ABI_VALUE_U64: u32      = 0b00000011 << 24;
-const ABI_VALUE_I64: u32      = 0b00000111 << 24;
+
+// TODO: Move to a more unified ABI helper library???
+pub const ABI_VALUE_U8: u32 = 0b00000000;
+pub const ABI_VALUE_I8: u32 = 0b00000100;
+pub const ABI_VALUE_U16: u32 = 0b00000010;
+pub const ABI_VALUE_I16: u32 = 0b00000110;
+pub const ABI_VALUE_U32: u32 = 0b00000001;
+pub const ABI_VALUE_I32: u32 = 0b00000101;
+pub const ABI_VALUE_U64: u32 = 0b00000011;
+pub const ABI_VALUE_I64: u32 = 0b00000111;
 
 // OR above type value with this to set byte indicating array value
 //const ABI_ARRAY_BIT: u32    = 0b00001000 << 24;
 
-
 macro_rules! write_comap_typed_with_abi {
     ($KEY:ident, $VALUE:ident, $TYPE:tt, $ABI_VALUE:expr) => {{
-        unsafe { 
+        unsafe {
             push_costack($KEY.as_bytes());
             push_costack_typed!($VALUE, $TYPE);
             __push_comap($ABI_VALUE);

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -244,7 +244,80 @@ pub fn write_comap_i8(key: &str, value: i8) {
     write_comap_typed_with_abi!(key, value, i8, ABI_VALUE_I8)
 }
 
+macro_rules! read_comap_typed_with_abi {
+    ($KEY:ident, $TYPE:tt) => {{
+        unsafe {
+            push_costack($KEY.as_bytes());
+            const BEGIN: usize = 0;
+            const SIZE: usize = core::mem::size_of::<$TYPE>();
+            __peek_result_comap(BEGIN, SIZE)
+        }
+    }};
+}
 
+/// Attempt to read a u64 comap value
+pub fn read_comap_u64(key: &str) -> Result<u64, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u64) {
+        ABI_VALUE_U64 => pop_costack_u64(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u32 comap value
+pub fn read_comap_u32(key: &str) -> Result<u32, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u32) {
+        ABI_VALUE_U32 => pop_costack_u32(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u16 comap value
+pub fn read_comap_u16(key: &str) -> Result<u16, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u16) {
+        ABI_VALUE_U16 => pop_costack_u16(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u8 comap value
+pub fn read_comap_u8(key: &str) -> Result<u8, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u8) {
+        ABI_VALUE_U8 => pop_costack_u8(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i64 comap value
+pub fn read_comap_i64(key: &str) -> Result<i64, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i64) {
+        ABI_VALUE_I64 => pop_costack_i64(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i32 comap value
+pub fn read_comap_i32(key: &str) -> Result<i32, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i32) {
+        ABI_VALUE_I32 => pop_costack_i32(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i16 comap value
+pub fn read_comap_i16(key: &str) -> Result<i16, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i16) {
+        ABI_VALUE_I16 => pop_costack_i16(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i8 comap value
+pub fn read_comap_i8(key: &str) -> Result<i8, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i8) {
+        ABI_VALUE_I8 => pop_costack_i8(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
 
 pub fn get_self_address() -> NeutronAddress {
     //TODO

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -80,47 +80,47 @@ macro_rules! pop_costack_typed {
     }};
 }
 
-/// Pops an exact u8 value from the stack.
+/// Pop an exact u8 value from the stack.
 pub fn pop_costack_u8() -> Result<u8, RecoverableError> {
     pop_costack_typed!(u8)
 }
 
-/// Pops an exact u16 value from the stack.
+/// Pop an exact u16 value from the stack.
 pub fn pop_costack_u16() -> Result<u16, RecoverableError> {
     pop_costack_typed!(u16)
 }
 
-/// Pops an exact u32 value from the stack.
+/// Pop an exact u32 value from the stack.
 pub fn pop_costack_u32() -> Result<u32, RecoverableError> {
     pop_costack_typed!(u32)
 }
 
-/// Pops an exact u64 value from the stack.
+/// Pop an exact u64 value from the stack.
 pub fn pop_costack_u64() -> Result<u64, RecoverableError> {
     pop_costack_typed!(u64)
 }
 
-/// Pops an exact i8 value from the stack.
+/// Pop an exact i8 value from the stack.
 pub fn pop_costack_i8() -> Result<i8, RecoverableError> {
     pop_costack_typed!(i8)
 }
 
-/// Pops an exact i16 value from the stack.
+/// Pop an exact i16 value from the stack.
 pub fn pop_costack_i16() -> Result<i16, RecoverableError> {
     pop_costack_typed!(i16)
 }
 
-/// Pops an exact i32 value from the stack.
+/// Pop an exact i32 value from the stack.
 pub fn pop_costack_i32() -> Result<i32, RecoverableError> {
     pop_costack_typed!(i32)
 }
 
-/// Pops an exact i64 value from the stack.
+/// Pop an exact i64 value from the stack.
 pub fn pop_costack_i64() -> Result<i64, RecoverableError> {
     pop_costack_typed!(i64)
 }
 
-/// Pops an exact NeutronAddress value from the stack.
+/// Pop an exact NeutronAddress value from the stack.
 pub fn pop_costack_address() -> Result<NeutronAddress, RecoverableError> {
     pop_costack_typed!(NeutronAddress)
 }
@@ -136,64 +136,63 @@ macro_rules! pop_costack_fixed_array_typed {
         let pointer = &mut$SLICE[0] as *mut $TYPE as *mut u8;
         let byte_slice = unsafe { slice::from_raw_parts_mut(pointer, $SLICE.len() * SIZE) };
 
-        let result = match pop_costack_fixed(byte_slice) {
+        let actual_length = match pop_costack_fixed(byte_slice) {
             Ok(v) => v,
             Err(_e) => return Err(RecoverableError::ItemDoesntExist),
         };
 
-        // For these functions we only allow the exact expected byte count
-        if result > ($SLICE.len() * SIZE) as u32 {
-            return Err(RecoverableError::StackItemTooLarge);
-        } else if result < ($SLICE.len() * SIZE) as u32 {
-            return Err(RecoverableError::StackItemTooSmall);
+        // Data has to be aligned to size of data type
+        if actual_length % (SIZE as u32) != 0 {
+            return Err(RecoverableError::StackItemTooLarge); // TODO: Replace with neutron-star error
         }
 
-        return Ok(());
+        // Return length in given type (actual_length is length in bytes)
+        return Ok(actual_length / (SIZE as u32));
     }};
 }
 
-/// Pops a fixed size u8 array from the stack.
-pub fn pop_costack_fixed_array_u8(slice: &mut [u8]) -> Result<(), RecoverableError> {
+/// Pop a u8 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_u8(slice: &mut [u8]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, u8)
 }
 
-/// Pops a fixed size u16 array from the stack.
-pub fn pop_costack_fixed_array_u16(slice: &mut [u16]) -> Result<(), RecoverableError> {
+/// Pop a u16 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_u16(slice: &mut [u16]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, u16)
 }
 
-/// Pops a fixed size u32 array from the stack.
-pub fn pop_costack_fixed_array_u32(slice: &mut [u32]) -> Result<(), RecoverableError> {
+/// Pop a u32 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_u32(slice: &mut [u32]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, u32)
 }
 
-/// Pops a fixed size u64 array from the stack.
-pub fn pop_costack_fixed_array_u64(slice: &mut [u64]) -> Result<(), RecoverableError> {
+/// Pop a u64 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_u64(slice: &mut [u64]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, u64)
 }
 
-/// Pops a fixed size i8 array from the stack.
-pub fn pop_costack_fixed_array_i8(slice: &mut [i8]) -> Result<(), RecoverableError> {
+/// Pop a i8 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_i8(slice: &mut [i8]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, i8)
 }
 
-/// Pops a fixed size i16 array from the stack.
-pub fn pop_costack_fixed_array_i16(slice: &mut [i16]) -> Result<(), RecoverableError> {
+/// Pop a i16 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_i16(slice: &mut [i16]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, i16)
 }
 
-/// Pops a fixed size i32 array from the stack.
-pub fn pop_costack_fixed_array_i32(slice: &mut [i32]) -> Result<(), RecoverableError> {
+/// Pop a i32 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_i32(slice: &mut [i32]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, i32)
 }
 
-/// Pops a fixed size i64 array from the stack.
-pub fn pop_costack_fixed_array_i64(slice: &mut [i64]) -> Result<(), RecoverableError> {
+/// Pop a i64 array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_i64(slice: &mut [i64]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, i64)
 }
 
-/// Pops a fixed size NeutronAddress array from the stack.
-pub fn pop_costack_fixed_array_address(slice: &mut [NeutronAddress]) -> Result<(), RecoverableError> {
+/// Pop a NeutronAddress array from the stack into provided slice, discard overflow, and return actual size of popped array.
+pub fn pop_costack_fixed_array_address(slice: &mut [NeutronAddress]) -> Result<u32, RecoverableError> {
     pop_costack_fixed_array_typed!(slice, NeutronAddress)
 }
 
@@ -253,7 +252,7 @@ pub fn push_costack_i64(value: i64) {
     push_costack_typed!(value, i64);
 }
 
-/// Pushes an exact NeutronAddress to the stack.
+/// Push an exact NeutronAddress to the stack.
 pub fn push_costack_address(value: &NeutronAddress) {
     push_costack_typed!(*value, NeutronAddress);
 }
@@ -271,47 +270,47 @@ macro_rules! push_costack_array_typed {
     }};
 }
 
-/// Pushes an u8 array to the stack.
+/// Push a u8 array to the stack.
 pub fn push_costack_array_u8(value: &[u8]) {
     push_costack(value); // No need for the macro since the slice is already byte sized
 }
 
-/// Pushes an u16 array to the stack.
+/// Push a u16 array to the stack.
 pub fn push_costack_array_u16(value: &[u16]) {
     push_costack_array_typed!(value, u16);
 }
 
-/// Pushes an u32 array to the stack.
+/// Push a u32 array to the stack.
 pub fn push_costack_array_u32(value: &[u32]) {
     push_costack_array_typed!(value, u32);
 }
 
-/// Pushes an u64 array to the stack.
+/// Push a u64 array to the stack.
 pub fn push_costack_array_u64(value: &[u64]) {
     push_costack_array_typed!(value, u64);
 }
 
-/// Pushes an i8 array to the stack.
+/// Push a i8 array to the stack.
 pub fn push_costack_array_i8(value: &[i8]) {
     push_costack_array_typed!(value, i8);
 }
 
-/// Pushes an i16 array to the stack.
+/// Push a i16 array to the stack.
 pub fn push_costack_array_i16(value: &[i16]) {
     push_costack_array_typed!(value, i16);
 }
 
-/// Pushes an i32 array to the stack.
+/// Push a i32 array to the stack.
 pub fn push_costack_array_i32(value: &[i32]) {
     push_costack_array_typed!(value, i32);
 }
 
-/// Pushes an i64 array to the stack.
+/// Push a i64 array to the stack.
 pub fn push_costack_array_i64(value: &[i64]) {
     push_costack_array_typed!(value, i64);
 }
 
-/// Pushes a NeutronAddress array to the stack.
+/// Push a NeutronAddress array to the stack.
 pub fn push_costack_array_address(value: &[NeutronAddress]) {
     push_costack_array_typed!(value, NeutronAddress);
 }
@@ -475,7 +474,7 @@ macro_rules! read_comap_typed_with_abi {
     }};
 }
 
-/// Attempt to read a u8 input comap value
+/// Read a u8 input comap value
 pub fn read_comap_u8(key: &str) -> Result<u8, RecoverableError> {
     match read_comap_typed_with_abi!(key, u8, "input_map") {
         ABI_VALUE_U8 => pop_costack_u8(),
@@ -483,7 +482,7 @@ pub fn read_comap_u8(key: &str) -> Result<u8, RecoverableError> {
     }
 }
 
-/// Attempt to read a u16 input comap value
+/// Read a u16 input comap value
 pub fn read_comap_u16(key: &str) -> Result<u16, RecoverableError> {
     match read_comap_typed_with_abi!(key, u16, "input_map") {
         ABI_VALUE_U16 => pop_costack_u16(),
@@ -491,7 +490,7 @@ pub fn read_comap_u16(key: &str) -> Result<u16, RecoverableError> {
     }
 }
 
-/// Attempt to read a u32 input comap value
+/// Read a u32 input comap value
 pub fn read_comap_u32(key: &str) -> Result<u32, RecoverableError> {
     match read_comap_typed_with_abi!(key, u32, "input_map") {
         ABI_VALUE_U32 => pop_costack_u32(),
@@ -499,7 +498,7 @@ pub fn read_comap_u32(key: &str) -> Result<u32, RecoverableError> {
     }
 }
 
-/// Attempt to read a u64 input comap value
+/// Read a u64 input comap value
 pub fn read_comap_u64(key: &str) -> Result<u64, RecoverableError> {
     match read_comap_typed_with_abi!(key, u64, "input_map") {
         ABI_VALUE_U64 => pop_costack_u64(),
@@ -507,7 +506,7 @@ pub fn read_comap_u64(key: &str) -> Result<u64, RecoverableError> {
     }
 }
 
-/// Attempt to read a i8 input comap value
+/// Read a i8 input comap value
 pub fn read_comap_i8(key: &str) -> Result<i8, RecoverableError> {
     match read_comap_typed_with_abi!(key, i8, "input_map") {
         ABI_VALUE_I8 => pop_costack_i8(),
@@ -515,7 +514,7 @@ pub fn read_comap_i8(key: &str) -> Result<i8, RecoverableError> {
     }
 }
 
-/// Attempt to read a i16 input comap value
+/// Read a i16 input comap value
 pub fn read_comap_i16(key: &str) -> Result<i16, RecoverableError> {
     match read_comap_typed_with_abi!(key, i16, "input_map") {
         ABI_VALUE_I16 => pop_costack_i16(),
@@ -523,7 +522,7 @@ pub fn read_comap_i16(key: &str) -> Result<i16, RecoverableError> {
     }
 }
 
-/// Attempt to read a i32 input comap value
+/// Read a i32 input comap value
 pub fn read_comap_i32(key: &str) -> Result<i32, RecoverableError> {
     match read_comap_typed_with_abi!(key, i32, "input_map") {
         ABI_VALUE_I32 => pop_costack_i32(),
@@ -531,7 +530,7 @@ pub fn read_comap_i32(key: &str) -> Result<i32, RecoverableError> {
     }
 }
 
-/// Attempt to read a i64 input comap value
+/// Read a i64 input comap value
 pub fn read_comap_i64(key: &str) -> Result<i64, RecoverableError> {
     match read_comap_typed_with_abi!(key, i64, "input_map") {
         ABI_VALUE_I64 => pop_costack_i64(),
@@ -541,7 +540,7 @@ pub fn read_comap_i64(key: &str) -> Result<i64, RecoverableError> {
 
 // read_result_comap_XXX
 
-/// Attempt to read a u8 result comap value
+/// Read a u8 result comap value
 pub fn read_result_comap_u8(key: &str) -> Result<u8, RecoverableError> {
     match read_comap_typed_with_abi!(key, u8, "result_map") {
         ABI_VALUE_U8 => pop_costack_u8(),
@@ -549,7 +548,7 @@ pub fn read_result_comap_u8(key: &str) -> Result<u8, RecoverableError> {
     }
 }
 
-/// Attempt to read a u16 result comap value
+/// Read a u16 result comap value
 pub fn read_result_comap_u16(key: &str) -> Result<u16, RecoverableError> {
     match read_comap_typed_with_abi!(key, u16, "result_map") {
         ABI_VALUE_U16 => pop_costack_u16(),
@@ -557,7 +556,7 @@ pub fn read_result_comap_u16(key: &str) -> Result<u16, RecoverableError> {
     }
 }
 
-/// Attempt to read a u32 result comap value
+/// Read a u32 result comap value
 pub fn read_result_comap_u32(key: &str) -> Result<u32, RecoverableError> {
     match read_comap_typed_with_abi!(key, u32, "result_map") {
         ABI_VALUE_U32 => pop_costack_u32(),
@@ -565,7 +564,7 @@ pub fn read_result_comap_u32(key: &str) -> Result<u32, RecoverableError> {
     }
 }
 
-/// Attempt to read a u64 result comap value
+/// Read a u64 result comap value
 pub fn read_result_comap_u64(key: &str) -> Result<u64, RecoverableError> {
     match read_comap_typed_with_abi!(key, u64, "result_map") {
         ABI_VALUE_U64 => pop_costack_u64(),
@@ -573,7 +572,7 @@ pub fn read_result_comap_u64(key: &str) -> Result<u64, RecoverableError> {
     }
 }
 
-/// Attempt to read a i8 result comap value
+/// Read a i8 result comap value
 pub fn read_result_comap_i8(key: &str) -> Result<i8, RecoverableError> {
     match read_comap_typed_with_abi!(key, i8, "result_map") {
         ABI_VALUE_I8 => pop_costack_i8(),
@@ -581,7 +580,7 @@ pub fn read_result_comap_i8(key: &str) -> Result<i8, RecoverableError> {
     }
 }
 
-/// Attempt to read a i16 result comap value
+/// Read a i16 result comap value
 pub fn read_result_comap_i16(key: &str) -> Result<i16, RecoverableError> {
     match read_comap_typed_with_abi!(key, i16, "result_map") {
         ABI_VALUE_I16 => pop_costack_i16(),
@@ -589,7 +588,7 @@ pub fn read_result_comap_i16(key: &str) -> Result<i16, RecoverableError> {
     }
 }
 
-/// Attempt to read a i32 result comap value
+/// Read a i32 result comap value
 pub fn read_result_comap_i32(key: &str) -> Result<i32, RecoverableError> {
     match read_comap_typed_with_abi!(key, i32, "result_map") {
         ABI_VALUE_I32 => pop_costack_i32(),
@@ -597,7 +596,7 @@ pub fn read_result_comap_i32(key: &str) -> Result<i32, RecoverableError> {
     }
 }
 
-/// Attempt to read a i64 result comap value
+/// Read a i64 result comap value
 pub fn read_result_comap_i64(key: &str) -> Result<i64, RecoverableError> {
     match read_comap_typed_with_abi!(key, i64, "result_map") {
         ABI_VALUE_I64 => pop_costack_i64(),
@@ -626,8 +625,8 @@ macro_rules! read_comap_fixed_array_typed_with_abi {
     }};
 }
 
-/// Attempt to read a u8 input comap array
-pub fn read_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> Result<(), RecoverableError> {
+/// Read a u8 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u8, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u8(return_slice),
@@ -635,8 +634,8 @@ pub fn read_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> Result<(
     }
 }
 
-/// Attempt to read a u16 input comap array
-pub fn read_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) -> Result<(), RecoverableError> {
+/// Read a u16 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u16, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u16(return_slice),
@@ -644,8 +643,8 @@ pub fn read_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) -> Result
     }
 }
 
-/// Attempt to read a u32 input comap array
-pub fn read_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) -> Result<(), RecoverableError> {
+/// Read a u32 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u32, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u32(return_slice),
@@ -653,8 +652,8 @@ pub fn read_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) -> Result
     }
 }
 
-/// Attempt to read a u64 input comap array
-pub fn read_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) -> Result<(), RecoverableError> {
+/// Read a u64 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u64, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u64(return_slice),
@@ -662,8 +661,8 @@ pub fn read_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) -> Result
     }
 }
 
-/// Attempt to read a i8 input comap array
-pub fn read_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> Result<(), RecoverableError> {
+/// Read a i8 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i8, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i8(return_slice),
@@ -671,8 +670,8 @@ pub fn read_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> Result<(
     }
 }
 
-/// Attempt to read a i16 input comap array
-pub fn read_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) -> Result<(), RecoverableError> {
+/// Read a i16 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i16, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i16(return_slice),
@@ -680,8 +679,8 @@ pub fn read_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) -> Result
     }
 }
 
-/// Attempt to read a i32 input comap array
-pub fn read_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) -> Result<(), RecoverableError> {
+/// Read a i32 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i32, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i32(return_slice),
@@ -689,8 +688,8 @@ pub fn read_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) -> Result
     }
 }
 
-/// Attempt to read a i64 input comap array
-pub fn read_comap_fixed_array_i64(key: &str, return_slice: &mut [i64]) -> Result<(), RecoverableError> {
+/// Read a i64 array from the input comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_comap_fixed_array_i64(key: &str, return_slice: &mut [i64]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i64, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i64(return_slice),
@@ -700,8 +699,8 @@ pub fn read_comap_fixed_array_i64(key: &str, return_slice: &mut [i64]) -> Result
 
 // read_result_comap_fixed_array_XXX(key, array slice)
 
-/// Attempt to read a u8 result comap array
-pub fn read_result_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> Result<(), RecoverableError> {
+/// Read a u8 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u8, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u8(return_slice),
@@ -709,8 +708,8 @@ pub fn read_result_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> R
     }
 }
 
-/// Attempt to read a u16 result comap array
-pub fn read_result_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) -> Result<(), RecoverableError> {
+/// Read a u16 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u16, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u16(return_slice),
@@ -718,8 +717,8 @@ pub fn read_result_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) ->
     }
 }
 
-/// Attempt to read a u32 result comap array
-pub fn read_result_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) -> Result<(), RecoverableError> {
+/// Read a u32 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u32, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u32(return_slice),
@@ -727,8 +726,8 @@ pub fn read_result_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) ->
     }
 }
 
-/// Attempt to read a u64 result comap array
-pub fn read_result_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) -> Result<(), RecoverableError> {
+/// Read a u64 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u64, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u64(return_slice),
@@ -736,8 +735,8 @@ pub fn read_result_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) ->
     }
 }
 
-/// Attempt to read a i8 result comap array
-pub fn read_result_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> Result<(), RecoverableError> {
+/// Read a i8 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i8, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i8(return_slice),
@@ -745,8 +744,8 @@ pub fn read_result_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> R
     }
 }
 
-/// Attempt to read a i16 result comap array
-pub fn read_result_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) -> Result<(), RecoverableError> {
+/// Read a i16 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i16, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i16(return_slice),
@@ -754,8 +753,8 @@ pub fn read_result_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) ->
     }
 }
 
-/// Attempt to read a i32 result comap array
-pub fn read_result_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) -> Result<(), RecoverableError> {
+/// Read a i32 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i32, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i32(return_slice),
@@ -763,8 +762,8 @@ pub fn read_result_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) ->
     }
 }
 
-/// Attempt to read a i64 result comap array
-pub fn read_result_comap_fixed_array_i64(key: &str, return_slice: &mut [i64]) -> Result<(), RecoverableError> {
+/// Read a i64 array from the result comap into provided slice, discard overflow, and return actual size of array.
+pub fn read_result_comap_fixed_array_i64(key: &str, return_slice: &mut [i64]) -> Result<u32, RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i64, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i64(return_slice),

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -406,14 +406,28 @@ pub fn write_comap_address(key: &str, value: NeutronAddress) {
 // write_comap_array_XXX(key, array slice)
 
 macro_rules! write_comap_array_typed_with_abi {
-    ($KEY:ident, $VALUE:ident, $TYPE:tt, $ABI_VALUE:expr) => {{
+    ($KEY:ident, $SLICE:ident, $TYPE:tt, $ABI_VALUE:expr) => {{
         unsafe {
-            crate::println!("boo!");
             push_costack($KEY.as_bytes());
-            push_costack_array_typed!($VALUE, $TYPE);
+            push_costack_array_typed!($SLICE, $TYPE);
             __push_comap($ABI_VALUE);
         }
     }};
+}
+
+/// Write a u8 comap array
+pub fn write_comap_array_u8(key: &str, value_slice: &[u8]) {
+    write_comap_array_typed_with_abi!(key, value_slice, u8, ABI_VALUE_U8 + ABI_ARRAY_BIT)
+}
+
+/// Write a u16 comap array
+pub fn write_comap_array_u16(key: &str, value_slice: &[u16]) {
+    write_comap_array_typed_with_abi!(key, value_slice, u16, ABI_VALUE_U16 + ABI_ARRAY_BIT)
+}
+
+/// Write a u32 comap array
+pub fn write_comap_array_u32(key: &str, value_slice: &[u32]) {
+    write_comap_array_typed_with_abi!(key, value_slice, u32, ABI_VALUE_U32 + ABI_ARRAY_BIT)
 }
 
 /// Write a u64 comap array
@@ -421,10 +435,39 @@ pub fn write_comap_array_u64(key: &str, value_slice: &[u64]) {
     write_comap_array_typed_with_abi!(key, value_slice, u64, ABI_VALUE_U64 + ABI_ARRAY_BIT)
 }
 
+/// Write a i8 comap array
+pub fn write_comap_array_i8(key: &str, value_slice: &[i8]) {
+    write_comap_array_typed_with_abi!(key, value_slice, i8, ABI_VALUE_I8 + ABI_ARRAY_BIT)
+}
+
+/// Write a i16 comap array
+pub fn write_comap_array_i16(key: &str, value_slice: &[i16]) {
+    write_comap_array_typed_with_abi!(key, value_slice, i16, ABI_VALUE_I16 + ABI_ARRAY_BIT)
+}
+
+/// Write a i32 comap array
+pub fn write_comap_array_i32(key: &str, value_slice: &[i32]) {
+    write_comap_array_typed_with_abi!(key, value_slice, i32, ABI_VALUE_I32 + ABI_ARRAY_BIT)
+}
+
+/// Write a i64 comap array
+pub fn write_comap_array_i64(key: &str, value_slice: &[i64]) {
+    write_comap_array_typed_with_abi!(key, value_slice, i64, ABI_VALUE_I64 + ABI_ARRAY_BIT)
+}
+
 // read_comap_XXX(key)
 
+// These two variants are identical save for reading either the input or result comap
 macro_rules! read_comap_typed_with_abi {
-    ($KEY:ident, $TYPE:tt) => {{
+    ($KEY:ident, $TYPE:tt, "input_map") => {{
+        unsafe {
+            push_costack($KEY.as_bytes());
+            const BEGIN: usize = 0;
+            const SIZE: usize = core::mem::size_of::<$TYPE>();
+            __peek_comap(BEGIN, SIZE)
+        }
+    }};
+    ($KEY:ident, $TYPE:tt, "result_map") => {{
         unsafe {
             push_costack($KEY.as_bytes());
             const BEGIN: usize = 0;
@@ -434,66 +477,347 @@ macro_rules! read_comap_typed_with_abi {
     }};
 }
 
-/// Attempt to read a u8 comap value
+/// Attempt to read a u8 input comap value
 pub fn read_comap_u8(key: &str) -> Result<u8, RecoverableError> {
-    match read_comap_typed_with_abi!(key, u8) {
+    match read_comap_typed_with_abi!(key, u8, "input_map") {
         ABI_VALUE_U8 => pop_costack_u8(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a u16 comap value
+/// Attempt to read a u16 input comap value
 pub fn read_comap_u16(key: &str) -> Result<u16, RecoverableError> {
-    match read_comap_typed_with_abi!(key, u16) {
+    match read_comap_typed_with_abi!(key, u16, "input_map") {
         ABI_VALUE_U16 => pop_costack_u16(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a u32 comap value
+/// Attempt to read a u32 input comap value
 pub fn read_comap_u32(key: &str) -> Result<u32, RecoverableError> {
-    match read_comap_typed_with_abi!(key, u32) {
+    match read_comap_typed_with_abi!(key, u32, "input_map") {
         ABI_VALUE_U32 => pop_costack_u32(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a u64 comap value
+/// Attempt to read a u64 input comap value
 pub fn read_comap_u64(key: &str) -> Result<u64, RecoverableError> {
-    match read_comap_typed_with_abi!(key, u64) {
+    match read_comap_typed_with_abi!(key, u64, "input_map") {
         ABI_VALUE_U64 => pop_costack_u64(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a i8 comap value
+/// Attempt to read a i8 input comap value
 pub fn read_comap_i8(key: &str) -> Result<i8, RecoverableError> {
-    match read_comap_typed_with_abi!(key, i8) {
+    match read_comap_typed_with_abi!(key, i8, "input_map") {
         ABI_VALUE_I8 => pop_costack_i8(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a i16 comap value
+/// Attempt to read a i16 input comap value
 pub fn read_comap_i16(key: &str) -> Result<i16, RecoverableError> {
-    match read_comap_typed_with_abi!(key, i16) {
+    match read_comap_typed_with_abi!(key, i16, "input_map") {
         ABI_VALUE_I16 => pop_costack_i16(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a i32 comap value
+/// Attempt to read a i32 input comap value
 pub fn read_comap_i32(key: &str) -> Result<i32, RecoverableError> {
-    match read_comap_typed_with_abi!(key, i32) {
+    match read_comap_typed_with_abi!(key, i32, "input_map") {
         ABI_VALUE_I32 => pop_costack_i32(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a i64 comap value
+/// Attempt to read a i64 input comap value
 pub fn read_comap_i64(key: &str) -> Result<i64, RecoverableError> {
-    match read_comap_typed_with_abi!(key, i64) {
+    match read_comap_typed_with_abi!(key, i64, "input_map") {
         ABI_VALUE_I64 => pop_costack_i64(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+// read_result_comap_XXX
+
+/// Attempt to read a u8 result comap value
+pub fn read_result_comap_u8(key: &str) -> Result<u8, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u8, "result_map") {
+        ABI_VALUE_U8 => pop_costack_u8(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u16 result comap value
+pub fn read_result_comap_u16(key: &str) -> Result<u16, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u16, "result_map") {
+        ABI_VALUE_U16 => pop_costack_u16(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u32 result comap value
+pub fn read_result_comap_u32(key: &str) -> Result<u32, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u32, "result_map") {
+        ABI_VALUE_U32 => pop_costack_u32(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u64 result comap value
+pub fn read_result_comap_u64(key: &str) -> Result<u64, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u64, "result_map") {
+        ABI_VALUE_U64 => pop_costack_u64(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i8 result comap value
+pub fn read_result_comap_i8(key: &str) -> Result<i8, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i8, "result_map") {
+        ABI_VALUE_I8 => pop_costack_i8(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i16 result comap value
+pub fn read_result_comap_i16(key: &str) -> Result<i16, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i16, "result_map") {
+        ABI_VALUE_I16 => pop_costack_i16(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i32 result comap value
+pub fn read_result_comap_i32(key: &str) -> Result<i32, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i32, "result_map") {
+        ABI_VALUE_I32 => pop_costack_i32(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i64 result comap value
+pub fn read_result_comap_i64(key: &str) -> Result<i64, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i64, "result_map") {
+        ABI_VALUE_I64 => pop_costack_i64(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+// read_comap_fixed_array_XXX(key, array slice)
+
+macro_rules! read_comap_fixed_array_typed_with_abi {
+    ($KEY:ident, $SLICE_LENGTH:expr, $TYPE:tt, "input_map") => {{
+        unsafe {
+            push_costack($KEY.as_bytes());
+            const BEGIN: usize = 0;
+            const SIZE: usize = core::mem::size_of::<$TYPE>();
+            __peek_comap(BEGIN, $SLICE_LENGTH * SIZE)
+        }
+    }};
+    ($KEY:ident, $SLICE_LENGTH:expr, $TYPE:tt, "result_map") => {{
+        unsafe {
+            push_costack($KEY.as_bytes());
+            const BEGIN: usize = 0;
+            const SIZE: usize = core::mem::size_of::<$TYPE>();
+            __peek_result_comap(BEGIN, $SLICE_LENGTH * SIZE)
+        }
+    }};
+}
+
+/// Attempt to read a u8 input comap array
+pub fn read_comap_fixed_array_u8(
+    key: &str,
+    return_slice: &mut [u8],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U8 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u8, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_u8(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u16 input comap array
+pub fn read_comap_fixed_array_u16(
+    key: &str,
+    return_slice: &mut [u16],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U16 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u16, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_u16(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u32 input comap array
+pub fn read_comap_fixed_array_u32(
+    key: &str,
+    return_slice: &mut [u32],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U32 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u32, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_u32(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u64 input comap array
+pub fn read_comap_fixed_array_u64(
+    key: &str,
+    return_slice: &mut [u64],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U64 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u64, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_u64(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i8 input comap array
+pub fn read_comap_fixed_array_i8(
+    key: &str,
+    return_slice: &mut [i8],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I8 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i8, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_i8(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i16 input comap array
+pub fn read_comap_fixed_array_i16(
+    key: &str,
+    return_slice: &mut [i16],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I16 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i16, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_i16(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i32 input comap array
+pub fn read_comap_fixed_array_i32(
+    key: &str,
+    return_slice: &mut [i32],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I32 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i32, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_i32(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i64 input comap array
+pub fn read_comap_fixed_array_i64(
+    key: &str,
+    return_slice: &mut [i64],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I64 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i64, "input_map") {
+        MATCH_VAL => pop_costack_fixed_array_i64(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+// read_result_comap_fixed_array_XXX(key, array slice)
+
+/// Attempt to read a u8 result comap array
+pub fn read_result_comap_fixed_array_u8(
+    key: &str,
+    return_slice: &mut [u8],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U8 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u8, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_u8(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u16 result comap array
+pub fn read_result_comap_fixed_array_u16(
+    key: &str,
+    return_slice: &mut [u16],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U16 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u16, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_u16(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u32 result comap array
+pub fn read_result_comap_fixed_array_u32(
+    key: &str,
+    return_slice: &mut [u32],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U32 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u32, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_u32(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a u64 result comap array
+pub fn read_result_comap_fixed_array_u64(
+    key: &str,
+    return_slice: &mut [u64],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_U64 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u64, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_u64(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i8 result comap array
+pub fn read_result_comap_fixed_array_i8(
+    key: &str,
+    return_slice: &mut [i8],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I8 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i8, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_i8(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i16 result comap array
+pub fn read_result_comap_fixed_array_i16(
+    key: &str,
+    return_slice: &mut [i16],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I16 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i16, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_i16(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i32 result comap array
+pub fn read_result_comap_fixed_array_i32(
+    key: &str,
+    return_slice: &mut [i32],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I32 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i32, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_i32(return_slice),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i64 result comap array
+pub fn read_result_comap_fixed_array_i64(
+    key: &str,
+    return_slice: &mut [i64],
+) -> Result<(), RecoverableError> {
+    const MATCH_VAL: u32 = ABI_VALUE_I64 + ABI_ARRAY_BIT;
+    match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i64, "result_map") {
+        MATCH_VAL => pop_costack_fixed_array_i64(return_slice),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -193,9 +193,7 @@ pub fn pop_costack_fixed_array_i64(slice: &mut [i64]) -> Result<(), RecoverableE
 }
 
 /// Pops a fixed size NeutronAddress array from the stack.
-pub fn pop_costack_fixed_array_address(
-    slice: &mut [NeutronAddress],
-) -> Result<(), RecoverableError> {
+pub fn pop_costack_fixed_array_address(slice: &mut [NeutronAddress]) -> Result<(), RecoverableError> {
     pop_costack_fixed_array_typed!(slice, NeutronAddress)
 }
 
@@ -629,10 +627,7 @@ macro_rules! read_comap_fixed_array_typed_with_abi {
 }
 
 /// Attempt to read a u8 input comap array
-pub fn read_comap_fixed_array_u8(
-    key: &str,
-    return_slice: &mut [u8],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u8, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u8(return_slice),
@@ -641,10 +636,7 @@ pub fn read_comap_fixed_array_u8(
 }
 
 /// Attempt to read a u16 input comap array
-pub fn read_comap_fixed_array_u16(
-    key: &str,
-    return_slice: &mut [u16],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u16, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u16(return_slice),
@@ -653,10 +645,7 @@ pub fn read_comap_fixed_array_u16(
 }
 
 /// Attempt to read a u32 input comap array
-pub fn read_comap_fixed_array_u32(
-    key: &str,
-    return_slice: &mut [u32],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u32, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u32(return_slice),
@@ -665,10 +654,7 @@ pub fn read_comap_fixed_array_u32(
 }
 
 /// Attempt to read a u64 input comap array
-pub fn read_comap_fixed_array_u64(
-    key: &str,
-    return_slice: &mut [u64],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u64, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_u64(return_slice),
@@ -677,10 +663,7 @@ pub fn read_comap_fixed_array_u64(
 }
 
 /// Attempt to read a i8 input comap array
-pub fn read_comap_fixed_array_i8(
-    key: &str,
-    return_slice: &mut [i8],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i8, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i8(return_slice),
@@ -689,10 +672,7 @@ pub fn read_comap_fixed_array_i8(
 }
 
 /// Attempt to read a i16 input comap array
-pub fn read_comap_fixed_array_i16(
-    key: &str,
-    return_slice: &mut [i16],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i16, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i16(return_slice),
@@ -701,10 +681,7 @@ pub fn read_comap_fixed_array_i16(
 }
 
 /// Attempt to read a i32 input comap array
-pub fn read_comap_fixed_array_i32(
-    key: &str,
-    return_slice: &mut [i32],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i32, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i32(return_slice),
@@ -713,10 +690,7 @@ pub fn read_comap_fixed_array_i32(
 }
 
 /// Attempt to read a i64 input comap array
-pub fn read_comap_fixed_array_i64(
-    key: &str,
-    return_slice: &mut [i64],
-) -> Result<(), RecoverableError> {
+pub fn read_comap_fixed_array_i64(key: &str, return_slice: &mut [i64]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i64, "input_map") {
         MATCH_VAL => pop_costack_fixed_array_i64(return_slice),
@@ -727,10 +701,7 @@ pub fn read_comap_fixed_array_i64(
 // read_result_comap_fixed_array_XXX(key, array slice)
 
 /// Attempt to read a u8 result comap array
-pub fn read_result_comap_fixed_array_u8(
-    key: &str,
-    return_slice: &mut [u8],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_u8(key: &str, return_slice: &mut [u8]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u8, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u8(return_slice),
@@ -739,10 +710,7 @@ pub fn read_result_comap_fixed_array_u8(
 }
 
 /// Attempt to read a u16 result comap array
-pub fn read_result_comap_fixed_array_u16(
-    key: &str,
-    return_slice: &mut [u16],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_u16(key: &str, return_slice: &mut [u16]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u16, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u16(return_slice),
@@ -751,10 +719,7 @@ pub fn read_result_comap_fixed_array_u16(
 }
 
 /// Attempt to read a u32 result comap array
-pub fn read_result_comap_fixed_array_u32(
-    key: &str,
-    return_slice: &mut [u32],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_u32(key: &str, return_slice: &mut [u32]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u32, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u32(return_slice),
@@ -763,10 +728,7 @@ pub fn read_result_comap_fixed_array_u32(
 }
 
 /// Attempt to read a u64 result comap array
-pub fn read_result_comap_fixed_array_u64(
-    key: &str,
-    return_slice: &mut [u64],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_u64(key: &str, return_slice: &mut [u64]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_U64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), u64, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_u64(return_slice),
@@ -775,10 +737,7 @@ pub fn read_result_comap_fixed_array_u64(
 }
 
 /// Attempt to read a i8 result comap array
-pub fn read_result_comap_fixed_array_i8(
-    key: &str,
-    return_slice: &mut [i8],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_i8(key: &str, return_slice: &mut [i8]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I8 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i8, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i8(return_slice),
@@ -787,10 +746,7 @@ pub fn read_result_comap_fixed_array_i8(
 }
 
 /// Attempt to read a i16 result comap array
-pub fn read_result_comap_fixed_array_i16(
-    key: &str,
-    return_slice: &mut [i16],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_i16(key: &str, return_slice: &mut [i16]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I16 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i16, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i16(return_slice),
@@ -799,10 +755,7 @@ pub fn read_result_comap_fixed_array_i16(
 }
 
 /// Attempt to read a i32 result comap array
-pub fn read_result_comap_fixed_array_i32(
-    key: &str,
-    return_slice: &mut [i32],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_i32(key: &str, return_slice: &mut [i32]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I32 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i32, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i32(return_slice),
@@ -811,10 +764,7 @@ pub fn read_result_comap_fixed_array_i32(
 }
 
 /// Attempt to read a i64 result comap array
-pub fn read_result_comap_fixed_array_i64(
-    key: &str,
-    return_slice: &mut [i64],
-) -> Result<(), RecoverableError> {
+pub fn read_result_comap_fixed_array_i64(key: &str, return_slice: &mut [i64]) -> Result<(), RecoverableError> {
     const MATCH_VAL: u32 = ABI_VALUE_I64 + ABI_ARRAY_BIT;
     match read_comap_fixed_array_typed_with_abi!(key, return_slice.len(), i64, "result_map") {
         MATCH_VAL => pop_costack_fixed_array_i64(return_slice),

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -50,6 +50,14 @@ pub fn discard_costack() {
     }
 }
 
+/************************************
+**                                 **
+**  Costack abstraction functions  **
+**                                 **
+************************************/
+
+// pop_costack_XXX()
+
 macro_rules! pop_costack_typed {
     ($TYPE:tt) => {{
         const SIZE: usize = core::mem::size_of::<$TYPE>();
@@ -70,14 +78,9 @@ macro_rules! pop_costack_typed {
     }};
 }
 
-/// Pops an exact u64 value from the stack.
-pub fn pop_costack_u64() -> Result<u64, RecoverableError> {
-    pop_costack_typed!(u64)
-}
-
-/// Pops an exact u32 value from the stack.
-pub fn pop_costack_u32() -> Result<u32, RecoverableError> {
-    pop_costack_typed!(u32)
+/// Pops an exact u8 value from the stack.
+pub fn pop_costack_u8() -> Result<u8, RecoverableError> {
+    pop_costack_typed!(u8)
 }
 
 /// Pops an exact u16 value from the stack.
@@ -85,19 +88,19 @@ pub fn pop_costack_u16() -> Result<u16, RecoverableError> {
     pop_costack_typed!(u16)
 }
 
-/// Pops an exact u8 value from the stack.
-pub fn pop_costack_u8() -> Result<u8, RecoverableError> {
-    pop_costack_typed!(u8)
+/// Pops an exact u32 value from the stack.
+pub fn pop_costack_u32() -> Result<u32, RecoverableError> {
+    pop_costack_typed!(u32)
 }
 
-/// Pops an exact i64 value from the stack.
-pub fn pop_costack_i64() -> Result<i64, RecoverableError> {
-    pop_costack_typed!(i64)
+/// Pops an exact u64 value from the stack.
+pub fn pop_costack_u64() -> Result<u64, RecoverableError> {
+    pop_costack_typed!(u64)
 }
 
-/// Pops an exact i32 value from the stack.
-pub fn pop_costack_i32() -> Result<i32, RecoverableError> {
-    pop_costack_typed!(i32)
+/// Pops an exact i8 value from the stack.
+pub fn pop_costack_i8() -> Result<i8, RecoverableError> {
+    pop_costack_typed!(i8)
 }
 
 /// Pops an exact i16 value from the stack.
@@ -105,9 +108,14 @@ pub fn pop_costack_i16() -> Result<i16, RecoverableError> {
     pop_costack_typed!(i16)
 }
 
-/// Pops an exact i8 value from the stack.
-pub fn pop_costack_i8() -> Result<i8, RecoverableError> {
-    pop_costack_typed!(i8)
+/// Pops an exact i32 value from the stack.
+pub fn pop_costack_i32() -> Result<i32, RecoverableError> {
+    pop_costack_typed!(i32)
+}
+
+/// Pops an exact i64 value from the stack.
+pub fn pop_costack_i64() -> Result<i64, RecoverableError> {
+    pop_costack_typed!(i64)
 }
 
 /// Pops an exact NeutronAddress value from the stack.
@@ -129,14 +137,9 @@ macro_rules! push_costack_typed {
     }};
 }
 
-/// Push an exact u64 value to the stack.
-pub fn push_costack_u64(value: u64) {
-    push_costack_typed!(value, u64);
-}
-
-/// Push an exact u32 value to the stack.
-pub fn push_costack_u32(value: u32) {
-    push_costack_typed!(value, u32);
+/// Push an exact u8 value to the stack.
+pub fn push_costack_u8(value: u8) {
+    push_costack_typed!(value, u8);
 }
 
 /// Push an exact u16 value to the stack.
@@ -144,24 +147,14 @@ pub fn push_costack_u16(value: u16) {
     push_costack_typed!(value, u16);
 }
 
-/// Push an exact u8 value to the stack.
-pub fn push_costack_u8(value: u8) {
-    push_costack_typed!(value, u8);
+/// Push an exact u32 value to the stack.
+pub fn push_costack_u32(value: u32) {
+    push_costack_typed!(value, u32);
 }
 
-/// Push an exact i64 value to the stack.
-pub fn push_costack_i64(value: i64) {
-    push_costack_typed!(value, i64);
-}
-
-/// Push an exact i32 value to the stack.
-pub fn push_costack_i32(value: i32) {
-    push_costack_typed!(value, i32);
-}
-
-/// Push an exact i16 value to the stack.
-pub fn push_costack_i16(value: i16) {
-    push_costack_typed!(value, i16);
+/// Push an exact u64 value to the stack.
+pub fn push_costack_u64(value: u64) {
+    push_costack_typed!(value, u64);
 }
 
 /// Push an exact i8 value to the stack.
@@ -169,10 +162,34 @@ pub fn push_costack_i8(value: i8) {
     push_costack_typed!(value, i8);
 }
 
+/// Push an exact i16 value to the stack.
+pub fn push_costack_i16(value: i16) {
+    push_costack_typed!(value, i16);
+}
+
+/// Push an exact i32 value to the stack.
+pub fn push_costack_i32(value: i32) {
+    push_costack_typed!(value, i32);
+}
+
+/// Push an exact i64 value to the stack.
+pub fn push_costack_i64(value: i64) {
+    push_costack_typed!(value, i64);
+}
+
 /// Pushes an exact NeutronAddress to the stack.
 pub fn push_costack_address(value: &NeutronAddress) {
     push_costack_typed!(*value, NeutronAddress);
 }
+
+/*****************************************
+**                                      **
+**  Simple comap abstraction functions  **
+**                                      **
+*****************************************/
+
+// ABI value constants
+// TODO: Move to a more unified ABI helper library???
 
 // All these are 1 byte headers -> only top byte is used, as following:
 // Bits 7-6 are 0   -> 1 byte header
@@ -181,18 +198,19 @@ pub fn push_costack_address(value: &NeutronAddress) {
 // Bit 3 is 0       -> not array
 // Bits 2-0 determine the actual type
 
-// TODO: Move to a more unified ABI helper library???
-pub const ABI_VALUE_U8: u32 = 0b00000000;
-pub const ABI_VALUE_I8: u32 = 0b00000100;
-pub const ABI_VALUE_U16: u32 = 0b00000010;
-pub const ABI_VALUE_I16: u32 = 0b00000110;
-pub const ABI_VALUE_U32: u32 = 0b00000001;
-pub const ABI_VALUE_I32: u32 = 0b00000101;
-pub const ABI_VALUE_U64: u32 = 0b00000011;
-pub const ABI_VALUE_I64: u32 = 0b00000111;
+pub const ABI_VALUE_U8: u32 = 0b0000_0000;
+pub const ABI_VALUE_I8: u32 = 0b0000_0100;
+pub const ABI_VALUE_U16: u32 = 0b0000_0010;
+pub const ABI_VALUE_I16: u32 = 0b0000_0110;
+pub const ABI_VALUE_U32: u32 = 0b0000_0001;
+pub const ABI_VALUE_I32: u32 = 0b0000_0101;
+pub const ABI_VALUE_U64: u32 = 0b0000_0011;
+pub const ABI_VALUE_I64: u32 = 0b0000_0111;
 
-// OR above type value with this to set byte indicating array value
-//const ABI_ARRAY_BIT: u32    = 0b00001000 << 24;
+// OR (or add...) above type value with this to set byte indicating array value
+pub const ABI_ARRAY_BIT: u32 = 0b0000_1000;
+
+// write_comap_XXX(key, value)
 
 macro_rules! write_comap_typed_with_abi {
     ($KEY:ident, $VALUE:ident, $TYPE:tt, $ABI_VALUE:expr) => {{
@@ -204,14 +222,9 @@ macro_rules! write_comap_typed_with_abi {
     }};
 }
 
-/// Write a u64 comap value
-pub fn write_comap_u64(key: &str, value: u64) {
-    write_comap_typed_with_abi!(key, value, u64, ABI_VALUE_U64)
-}
-
-/// Write a u32 comap value
-pub fn write_comap_u32(key: &str, value: u32) {
-    write_comap_typed_with_abi!(key, value, u32, ABI_VALUE_U32)
+/// Write a u8 comap value
+pub fn write_comap_u8(key: &str, value: u8) {
+    write_comap_typed_with_abi!(key, value, u8, ABI_VALUE_U8)
 }
 
 /// Write a u16 comap value
@@ -219,19 +232,19 @@ pub fn write_comap_u16(key: &str, value: u16) {
     write_comap_typed_with_abi!(key, value, u16, ABI_VALUE_U16)
 }
 
-/// Write a u8 comap value
-pub fn write_comap_u8(key: &str, value: u8) {
-    write_comap_typed_with_abi!(key, value, u8, ABI_VALUE_U8)
+/// Write a u32 comap value
+pub fn write_comap_u32(key: &str, value: u32) {
+    write_comap_typed_with_abi!(key, value, u32, ABI_VALUE_U32)
 }
 
-/// Write a i64 comap value
-pub fn write_comap_i64(key: &str, value: i64) {
-    write_comap_typed_with_abi!(key, value, i64, ABI_VALUE_I64)
+/// Write a u64 comap value
+pub fn write_comap_u64(key: &str, value: u64) {
+    write_comap_typed_with_abi!(key, value, u64, ABI_VALUE_U64)
 }
 
-/// Write a i32 comap value
-pub fn write_comap_i32(key: &str, value: i32) {
-    write_comap_typed_with_abi!(key, value, i32, ABI_VALUE_I32)
+/// Write a i8 comap value
+pub fn write_comap_i8(key: &str, value: i8) {
+    write_comap_typed_with_abi!(key, value, i8, ABI_VALUE_I8)
 }
 
 /// Write a i16 comap value
@@ -239,10 +252,40 @@ pub fn write_comap_i16(key: &str, value: i16) {
     write_comap_typed_with_abi!(key, value, i16, ABI_VALUE_I16)
 }
 
-/// Write a i8 comap value
-pub fn write_comap_i8(key: &str, value: i8) {
-    write_comap_typed_with_abi!(key, value, i8, ABI_VALUE_I8)
+/// Write a i32 comap value
+pub fn write_comap_i32(key: &str, value: i32) {
+    write_comap_typed_with_abi!(key, value, i32, ABI_VALUE_I32)
 }
+
+/// Write a i64 comap value
+pub fn write_comap_i64(key: &str, value: i64) {
+    write_comap_typed_with_abi!(key, value, i64, ABI_VALUE_I64)
+}
+
+/// Write a NeutronAddress comap value
+pub fn write_comap_address(key: &str, value: NeutronAddress) {
+    write_comap_typed_with_abi!(key, value, NeutronAddress, ABI_VALUE_I8)
+}
+
+// write_comap_array_XXX(key, array slice)
+
+macro_rules! write_comap_array_typed_with_abi {
+    ($KEY:ident, $VALUE:ident, $TYPE:tt, $ABI_VALUE:expr) => {{
+        unsafe {
+            crate::println!("boo!");
+            push_costack($KEY.as_bytes());
+            push_costack_array_typed!($VALUE, $TYPE);
+            __push_comap($ABI_VALUE);
+        }
+    }};
+}
+
+/// Write a u64 comap array
+pub fn write_comap_array_u64(key: &str, value_slice: &[u64]) {
+    write_comap_array_typed_with_abi!(key, value_slice, u64, ABI_VALUE_U64 + ABI_ARRAY_BIT)
+}
+
+// read_comap_XXX(key)
 
 macro_rules! read_comap_typed_with_abi {
     ($KEY:ident, $TYPE:tt) => {{
@@ -255,18 +298,10 @@ macro_rules! read_comap_typed_with_abi {
     }};
 }
 
-/// Attempt to read a u64 comap value
-pub fn read_comap_u64(key: &str) -> Result<u64, RecoverableError> {
-    match read_comap_typed_with_abi!(key, u64) {
-        ABI_VALUE_U64 => pop_costack_u64(),
-        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
-    }
-}
-
-/// Attempt to read a u32 comap value
-pub fn read_comap_u32(key: &str) -> Result<u32, RecoverableError> {
-    match read_comap_typed_with_abi!(key, u32) {
-        ABI_VALUE_U32 => pop_costack_u32(),
+/// Attempt to read a u8 comap value
+pub fn read_comap_u8(key: &str) -> Result<u8, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u8) {
+        ABI_VALUE_U8 => pop_costack_u8(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
@@ -279,26 +314,26 @@ pub fn read_comap_u16(key: &str) -> Result<u16, RecoverableError> {
     }
 }
 
-/// Attempt to read a u8 comap value
-pub fn read_comap_u8(key: &str) -> Result<u8, RecoverableError> {
-    match read_comap_typed_with_abi!(key, u8) {
-        ABI_VALUE_U8 => pop_costack_u8(),
+/// Attempt to read a u32 comap value
+pub fn read_comap_u32(key: &str) -> Result<u32, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u32) {
+        ABI_VALUE_U32 => pop_costack_u32(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a i64 comap value
-pub fn read_comap_i64(key: &str) -> Result<i64, RecoverableError> {
-    match read_comap_typed_with_abi!(key, i64) {
-        ABI_VALUE_I64 => pop_costack_i64(),
+/// Attempt to read a u64 comap value
+pub fn read_comap_u64(key: &str) -> Result<u64, RecoverableError> {
+    match read_comap_typed_with_abi!(key, u64) {
+        ABI_VALUE_U64 => pop_costack_u64(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
 
-/// Attempt to read a i32 comap value
-pub fn read_comap_i32(key: &str) -> Result<i32, RecoverableError> {
-    match read_comap_typed_with_abi!(key, i32) {
-        ABI_VALUE_I32 => pop_costack_i32(),
+/// Attempt to read a i8 comap value
+pub fn read_comap_i8(key: &str) -> Result<i8, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i8) {
+        ABI_VALUE_I8 => pop_costack_i8(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }
@@ -311,10 +346,18 @@ pub fn read_comap_i16(key: &str) -> Result<i16, RecoverableError> {
     }
 }
 
-/// Attempt to read a i8 comap value
-pub fn read_comap_i8(key: &str) -> Result<i8, RecoverableError> {
-    match read_comap_typed_with_abi!(key, i8) {
-        ABI_VALUE_I8 => pop_costack_i8(),
+/// Attempt to read a i32 comap value
+pub fn read_comap_i32(key: &str) -> Result<i32, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i32) {
+        ABI_VALUE_I32 => pop_costack_i32(),
+        _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
+    }
+}
+
+/// Attempt to read a i64 comap value
+pub fn read_comap_i64(key: &str) -> Result<i64, RecoverableError> {
+    match read_comap_typed_with_abi!(key, i64) {
+        ABI_VALUE_I64 => pop_costack_i64(),
         _ => Err(RecoverableError::ItemDoesntExist), // TODO: Custom neutron-star error
     }
 }


### PR DESCRIPTION
(Part of a joint PR to here, neutron-star-rt, and neutron-host)

* Add abstraction functions for pushing/popping of costack integer (+address) arrays. 

* Add abstraction functions for reading/writing single and array integer (+address) costack entries. 